### PR TITLE
feat: add freeze and unfreeze commands with player action listener

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.1.0-beta
+version=1.21.8-1.0.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.0.0-beta
+version=1.1.0-beta

--- a/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
@@ -22,7 +22,6 @@ class BukkitMain : SuspendingJavaPlugin() {
 
         PlayerActionListener().register()
 
-        logger.info("${this.name} Successfully enabled.")
     }
 
     override suspend fun onDisableAsync() {

--- a/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
@@ -1,6 +1,7 @@
 package dev.slne.surfModerationTools
 
 import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
+import dev.slne.surf.surfapi.bukkit.api.event.register
 import dev.slne.surfModerationTools.commands.freezeCommand
 import dev.slne.surfModerationTools.commands.rotateCommand
 import dev.slne.surfModerationTools.commands.unfreezeCommand

--- a/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
@@ -18,7 +18,6 @@ class BukkitMain : SuspendingJavaPlugin() {
         freezeCommand()
         unfreezeCommand()
 
-        val manager = server.pluginManager
 
         PlayerActionListener().register()
 

--- a/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
@@ -20,7 +20,7 @@ class BukkitMain : SuspendingJavaPlugin() {
 
         val manager = server.pluginManager
 
-        manager.registerEvents(PlayerActionListener(), this)
+        PlayerActionListener().register()
 
         logger.info("${this.name} Successfully enabled.")
     }

--- a/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
@@ -1,7 +1,10 @@
 package dev.slne.surfModerationTools
 
 import com.github.shynixn.mccoroutine.folia.SuspendingJavaPlugin
+import dev.slne.surfModerationTools.commands.freezeCommand
 import dev.slne.surfModerationTools.commands.rotateCommand
+import dev.slne.surfModerationTools.commands.unfreezeCommand
+import dev.slne.surfModerationTools.listener.PlayerActionListener
 import org.bukkit.plugin.java.JavaPlugin
 import kotlin.jvm.java
 
@@ -10,9 +13,19 @@ val plugin get() = JavaPlugin.getPlugin(BukkitMain::class.java)
 class BukkitMain : SuspendingJavaPlugin() {
 
     override suspend fun onEnableAsync() {
+
         rotateCommand()
+        freezeCommand()
+        unfreezeCommand()
+
+        val manager = server.pluginManager
+
+        manager.registerEvents(PlayerActionListener(), this)
+
+        logger.info("${this.name} Successfully enabled.")
     }
 
     override suspend fun onDisableAsync() {
+        logger.info("Bye <3")
     }
 }

--- a/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/BukkitMain.kt
@@ -26,6 +26,5 @@ class BukkitMain : SuspendingJavaPlugin() {
     }
 
     override suspend fun onDisableAsync() {
-        logger.info("Bye <3")
     }
 }

--- a/src/main/kotlin/dev/slne/surfModerationTools/commands/FreezeCommand.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/commands/FreezeCommand.kt
@@ -1,0 +1,42 @@
+package dev.slne.surfModerationTools.commands
+
+import com.github.shynixn.mccoroutine.folia.entityDispatcher
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.commandAPICommand
+import dev.jorel.commandapi.kotlindsl.getValue
+import dev.jorel.commandapi.kotlindsl.playerArgument
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import dev.slne.surfModerationTools.permissions.Permissions
+import dev.slne.surfModerationTools.plugin
+import dev.slne.surfModerationTools.utils.FreezeManager
+import org.bukkit.entity.Player
+
+fun freezeCommand() = commandAPICommand("freeze") {
+    playerArgument("targetPlayer")
+    withPermission(Permissions.COMMAND_FREEZE)
+
+    anyExecutor { sender, args ->
+        val targetPlayer: Player by args
+
+        plugin.launch(plugin.entityDispatcher(targetPlayer)) {
+
+            if (!FreezeManager.freezePlayer(targetPlayer)) {
+                sender.sendText {
+                    appendPrefix()
+                    error("Der Spieler ")
+                    variableValue(targetPlayer.name)
+                    error(" ist bereits eingefroren.")
+                }
+                return@launch
+            }
+
+            sender.sendText {
+                appendPrefix()
+                success("Der Spieler ")
+                variableValue(targetPlayer.name)
+                success(" wurde erfolgreich eingefroren.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surfModerationTools/commands/FreezeCommand.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/commands/FreezeCommand.kt
@@ -1,14 +1,11 @@
 package dev.slne.surfModerationTools.commands
 
-import com.github.shynixn.mccoroutine.folia.entityDispatcher
-import com.github.shynixn.mccoroutine.folia.launch
 import dev.jorel.commandapi.kotlindsl.anyExecutor
 import dev.jorel.commandapi.kotlindsl.commandAPICommand
 import dev.jorel.commandapi.kotlindsl.getValue
 import dev.jorel.commandapi.kotlindsl.playerArgument
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import dev.slne.surfModerationTools.permissions.Permissions
-import dev.slne.surfModerationTools.plugin
 import dev.slne.surfModerationTools.utils.FreezeManager
 import org.bukkit.entity.Player
 
@@ -19,24 +16,22 @@ fun freezeCommand() = commandAPICommand("freeze") {
     anyExecutor { sender, args ->
         val targetPlayer: Player by args
 
-        plugin.launch(plugin.entityDispatcher(targetPlayer)) {
-
-            if (!FreezeManager.freezePlayer(targetPlayer)) {
-                sender.sendText {
-                    appendPrefix()
-                    error("Der Spieler ")
-                    variableValue(targetPlayer.name)
-                    error(" ist bereits eingefroren.")
-                }
-                return@launch
-            }
-
+        if (!FreezeManager.freezePlayer(targetPlayer)) {
             sender.sendText {
                 appendPrefix()
-                success("Der Spieler ")
+                error("Der Spieler ")
                 variableValue(targetPlayer.name)
-                success(" wurde erfolgreich eingefroren.")
+                error(" ist bereits eingefroren.")
             }
+            return@anyExecutor
         }
+
+        sender.sendText {
+            appendPrefix()
+            success("Der Spieler ")
+            variableValue(targetPlayer.name)
+            success(" wurde erfolgreich eingefroren.")
+        }
+
     }
 }

--- a/src/main/kotlin/dev/slne/surfModerationTools/commands/UnfreezeCommand.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/commands/UnfreezeCommand.kt
@@ -1,14 +1,11 @@
 package dev.slne.surfModerationTools.commands
 
-import com.github.shynixn.mccoroutine.folia.entityDispatcher
-import com.github.shynixn.mccoroutine.folia.launch
 import dev.jorel.commandapi.kotlindsl.anyExecutor
 import dev.jorel.commandapi.kotlindsl.commandAPICommand
 import dev.jorel.commandapi.kotlindsl.getValue
 import dev.jorel.commandapi.kotlindsl.playerArgument
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import dev.slne.surfModerationTools.permissions.Permissions
-import dev.slne.surfModerationTools.plugin
 import dev.slne.surfModerationTools.utils.FreezeManager
 import org.bukkit.entity.Player
 
@@ -19,24 +16,21 @@ fun unfreezeCommand() = commandAPICommand("unfreeze") {
     anyExecutor { sender, args ->
         val targetPlayer: Player by args
 
-        plugin.launch(plugin.entityDispatcher(targetPlayer)) {
-
-            if(!FreezeManager.unfreezePlayer(targetPlayer)) {
-                sender.sendText {
-                    appendPrefix()
-                    error("Der Spieler ")
-                    variableValue(targetPlayer.name)
-                    error(" ist nicht eingefroren.")
-                }
-                return@launch
-            }
-
+        if (!FreezeManager.unfreezePlayer(targetPlayer)) {
             sender.sendText {
                 appendPrefix()
-                success("Der Spieler ")
+                error("Der Spieler ")
                 variableValue(targetPlayer.name)
-                success(" wurde erfolgreich aufgetaut.")
+                error(" ist nicht eingefroren.")
             }
+            return@anyExecutor
+        }
+
+        sender.sendText {
+            appendPrefix()
+            success("Der Spieler ")
+            variableValue(targetPlayer.name)
+            success(" wurde erfolgreich aufgetaut.")
         }
     }
 }

--- a/src/main/kotlin/dev/slne/surfModerationTools/commands/UnfreezeCommand.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/commands/UnfreezeCommand.kt
@@ -1,0 +1,42 @@
+package dev.slne.surfModerationTools.commands
+
+import com.github.shynixn.mccoroutine.folia.entityDispatcher
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.jorel.commandapi.kotlindsl.anyExecutor
+import dev.jorel.commandapi.kotlindsl.commandAPICommand
+import dev.jorel.commandapi.kotlindsl.getValue
+import dev.jorel.commandapi.kotlindsl.playerArgument
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import dev.slne.surfModerationTools.permissions.Permissions
+import dev.slne.surfModerationTools.plugin
+import dev.slne.surfModerationTools.utils.FreezeManager
+import org.bukkit.entity.Player
+
+fun unfreezeCommand() = commandAPICommand("unfreeze") {
+    playerArgument("targetPlayer")
+    withPermission(Permissions.COMMAND_UNFREEZE)
+
+    anyExecutor { sender, args ->
+        val targetPlayer: Player by args
+
+        plugin.launch(plugin.entityDispatcher(targetPlayer)) {
+
+            if(!FreezeManager.unfreezePlayer(targetPlayer)) {
+                sender.sendText {
+                    appendPrefix()
+                    error("Der Spieler ")
+                    variableValue(targetPlayer.name)
+                    error(" ist nicht eingefroren.")
+                }
+                return@launch
+            }
+
+            sender.sendText {
+                appendPrefix()
+                success("Der Spieler ")
+                variableValue(targetPlayer.name)
+                success(" wurde erfolgreich aufgetaut.")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
@@ -1,0 +1,113 @@
+package dev.slne.surfModerationTools.listener
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.shynixn.mccoroutine.folia.entityDispatcher
+import com.github.shynixn.mccoroutine.folia.launch
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import dev.slne.surfModerationTools.plugin
+import dev.slne.surfModerationTools.utils.FreezeManager
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.block.BlockBreakEvent
+import org.bukkit.event.block.BlockPlaceEvent
+import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.player.PlayerInteractEntityEvent
+import org.bukkit.event.player.PlayerInteractEvent
+import org.bukkit.event.player.PlayerMoveEvent
+import org.bukkit.event.player.PlayerQuitEvent
+import java.util.concurrent.TimeUnit
+
+class PlayerActionListener : Listener {
+
+    private val messageCooldown = Caffeine.newBuilder()
+        .expireAfterWrite(2, TimeUnit.SECONDS)
+        .build<Player, Boolean>()
+
+    private fun sendFrozenMessage(player: Player, message: String) {
+        if (messageCooldown.getIfPresent(player) == null) {
+            player.sendText {
+                appendPrefix()
+                error(message)
+            }
+            messageCooldown.put(player, true)
+        }
+    }
+
+
+    @EventHandler
+    fun onPlayerMove(event: PlayerMoveEvent) {
+        val player = event.player
+        plugin.launch(plugin.entityDispatcher(event.player)) {
+            if (FreezeManager.isPlayerFrozen(player)) {
+                sendFrozenMessage(player, "Du bist eingefroren und kannst dich nicht bewegen.")
+                event.isCancelled = true
+            }
+        }
+    }
+
+    @EventHandler
+    fun onPlayerBlockBreak(event: BlockBreakEvent) {
+        val player = event.player
+        plugin.launch(plugin.entityDispatcher(event.player)) {
+            if (FreezeManager.isPlayerFrozen(player)) {
+                sendFrozenMessage(player, "Du bist eingefroren und kannst nichts abbauen.")
+                event.isCancelled = true
+            }
+        }
+    }
+
+    @EventHandler
+    fun onPlayerBlockPlace(event: BlockPlaceEvent) {
+        val player = event.player
+        plugin.launch(plugin.entityDispatcher(player)) {
+            if (FreezeManager.isPlayerFrozen(player)) {
+                sendFrozenMessage(player, "Du bist eingefroren und kannst nichts platzieren.")
+                event.isCancelled = true
+            }
+        }
+    }
+
+    @EventHandler
+    fun onPlayerAttack(event: EntityDamageByEntityEvent) {
+        val damager = event.damager
+        plugin.launch(plugin.entityDispatcher(damager)) {
+            if (damager is Player) {
+                sendFrozenMessage(damager, "Du bist eingefroren und kannst niemanden angreifen.")
+                if (FreezeManager.isPlayerFrozen(damager)) {
+                    event.isCancelled = true
+                }
+            }
+        }
+    }
+
+    @EventHandler
+    fun onPlayerInteract(event: PlayerInteractEvent) {
+        val player = event.player
+        plugin.launch(plugin.entityDispatcher(player)) {
+            if (FreezeManager.isPlayerFrozen(player)) {
+                sendFrozenMessage(player, "Du bist eingefroren und kannst nichts benutzen.")
+                event.isCancelled = true
+            }
+        }
+    }
+
+    @EventHandler
+    fun onPlayerInteract(event: PlayerInteractEntityEvent) {
+        val player = event.player
+        plugin.launch(plugin.entityDispatcher(player)) {
+            if (FreezeManager.isPlayerFrozen(player)) {
+                sendFrozenMessage(player, "Du bist eingefroren und kannst nichts benutzen.")
+                event.isCancelled = true
+            }
+        }
+    }
+
+    @EventHandler
+    fun onPlayerQuit(event: PlayerQuitEvent) {
+        val player = event.player
+        plugin.launch(plugin.entityDispatcher(player)) {
+            FreezeManager.unfreezePlayer(player)
+        }
+    }
+}

--- a/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
@@ -25,7 +25,7 @@ class PlayerActionListener : Listener {
         .build<UUID, Long>()
 
     private fun sendFrozenMessage(player: Player, message: String) {
-        if (messageCooldown.getIfPresent(player) == null) {
+        if (messageCooldown.getOrDefault(player.uniqueId, 0L) < System.currentTimeMillis) {
             player.sendText {
                 appendPrefix()
                 error(message)

--- a/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
@@ -22,7 +22,7 @@ class PlayerActionListener : Listener {
 
     private val messageCooldown = Caffeine.newBuilder()
         .expireAfterWrite(2, TimeUnit.SECONDS)
-        .build<Player, Boolean>()
+        .build<UUID, Long>()
 
     private fun sendFrozenMessage(player: Player, message: String) {
         if (messageCooldown.getIfPresent(player) == null) {

--- a/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
@@ -30,7 +30,7 @@ class PlayerActionListener : Listener {
                 appendPrefix()
                 error(message)
             }
-            messageCooldown.put(player, true)
+            messageCooldown.put(player.uniqueId, System.currentTimeMillis() + 3_000)
         }
     }
 

--- a/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
@@ -34,7 +34,6 @@ class PlayerActionListener : Listener {
         }
     }
 
-
     @EventHandler
     fun onPlayerMove(event: PlayerMoveEvent) {
         val player = event.player

--- a/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
@@ -1,10 +1,7 @@
 package dev.slne.surfModerationTools.listener
 
 import com.github.benmanes.caffeine.cache.Caffeine
-import com.github.shynixn.mccoroutine.folia.entityDispatcher
-import com.github.shynixn.mccoroutine.folia.launch
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
-import dev.slne.surfModerationTools.plugin
 import dev.slne.surfModerationTools.utils.FreezeManager
 import org.bukkit.entity.Player
 import org.bukkit.event.EventHandler
@@ -16,97 +13,86 @@ import org.bukkit.event.player.PlayerInteractEntityEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.player.PlayerMoveEvent
 import org.bukkit.event.player.PlayerQuitEvent
+import java.util.UUID
 import java.util.concurrent.TimeUnit
 
 class PlayerActionListener : Listener {
 
     private val messageCooldown = Caffeine.newBuilder()
-        .expireAfterWrite(2, TimeUnit.SECONDS)
+        .expireAfterWrite(5, TimeUnit.SECONDS)
         .build<UUID, Long>()
 
     private fun sendFrozenMessage(player: Player, message: String) {
-        if (messageCooldown.getOrDefault(player.uniqueId, 0L) < System.currentTimeMillis) {
+        if ((messageCooldown.getIfPresent(player.uniqueId) ?: 0) < System.currentTimeMillis()) {
             player.sendText {
                 appendPrefix()
                 error(message)
             }
-            messageCooldown.put(player.uniqueId, System.currentTimeMillis() + 3_000)
+            messageCooldown.put(player.uniqueId, System.currentTimeMillis() + 5_000)
         }
     }
 
     @EventHandler
     fun onPlayerMove(event: PlayerMoveEvent) {
         val player = event.player
-        plugin.launch(plugin.entityDispatcher(event.player)) {
-            if (FreezeManager.isPlayerFrozen(player)) {
-                sendFrozenMessage(player, "Du bist eingefroren und kannst dich nicht bewegen.")
-                event.isCancelled = true
-            }
+        if (FreezeManager.isPlayerFrozen(player)) {
+            sendFrozenMessage(player, "Du bist eingefroren und kannst dich nicht bewegen.")
+            event.isCancelled = true
         }
     }
 
     @EventHandler
     fun onPlayerBlockBreak(event: BlockBreakEvent) {
         val player = event.player
-        plugin.launch(plugin.entityDispatcher(event.player)) {
-            if (FreezeManager.isPlayerFrozen(player)) {
-                sendFrozenMessage(player, "Du bist eingefroren und kannst nichts abbauen.")
-                event.isCancelled = true
-            }
+        if (FreezeManager.isPlayerFrozen(player)) {
+            sendFrozenMessage(player, "Du bist eingefroren und kannst nichts abbauen.")
+            event.isCancelled = true
         }
+
     }
 
     @EventHandler
     fun onPlayerBlockPlace(event: BlockPlaceEvent) {
         val player = event.player
-        plugin.launch(plugin.entityDispatcher(player)) {
-            if (FreezeManager.isPlayerFrozen(player)) {
-                sendFrozenMessage(player, "Du bist eingefroren und kannst nichts platzieren.")
-                event.isCancelled = true
-            }
+        if (FreezeManager.isPlayerFrozen(player)) {
+            sendFrozenMessage(player, "Du bist eingefroren und kannst nichts platzieren.")
+            event.isCancelled = true
         }
     }
 
     @EventHandler
     fun onPlayerAttack(event: EntityDamageByEntityEvent) {
         val damager = event.damager
-        plugin.launch(plugin.entityDispatcher(damager)) {
-            if (damager is Player) {
-                sendFrozenMessage(damager, "Du bist eingefroren und kannst niemanden angreifen.")
-                if (FreezeManager.isPlayerFrozen(damager)) {
-                    event.isCancelled = true
-                }
+        if (damager is Player) {
+            sendFrozenMessage(damager, "Du bist eingefroren und kannst niemanden angreifen.")
+            if (FreezeManager.isPlayerFrozen(damager)) {
+                event.isCancelled = true
             }
         }
+
     }
 
     @EventHandler
     fun onPlayerInteract(event: PlayerInteractEvent) {
         val player = event.player
-        plugin.launch(plugin.entityDispatcher(player)) {
-            if (FreezeManager.isPlayerFrozen(player)) {
-                sendFrozenMessage(player, "Du bist eingefroren und kannst nichts benutzen.")
-                event.isCancelled = true
-            }
+        if (FreezeManager.isPlayerFrozen(player)) {
+            sendFrozenMessage(player, "Du bist eingefroren und kannst nichts benutzen.")
+            event.isCancelled = true
         }
     }
 
     @EventHandler
     fun onPlayerInteract(event: PlayerInteractEntityEvent) {
         val player = event.player
-        plugin.launch(plugin.entityDispatcher(player)) {
-            if (FreezeManager.isPlayerFrozen(player)) {
-                sendFrozenMessage(player, "Du bist eingefroren und kannst nichts benutzen.")
-                event.isCancelled = true
-            }
+        if (FreezeManager.isPlayerFrozen(player)) {
+            sendFrozenMessage(player, "Du bist eingefroren und kannst nichts benutzen.")
+            event.isCancelled = true
         }
     }
 
     @EventHandler
     fun onPlayerQuit(event: PlayerQuitEvent) {
         val player = event.player
-        plugin.launch(plugin.entityDispatcher(player)) {
-            FreezeManager.unfreezePlayer(player)
-        }
+        FreezeManager.unfreezePlayer(player)
     }
 }

--- a/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
@@ -64,8 +64,8 @@ class PlayerActionListener : Listener {
     fun onPlayerAttack(event: EntityDamageByEntityEvent) {
         val damager = event.damager
         if (damager is Player) {
-            sendFrozenMessage(damager, "Du bist eingefroren und kannst niemanden angreifen.")
             if (FreezeManager.isPlayerFrozen(damager)) {
+                sendFrozenMessage(damager, "Du bist eingefroren und kannst niemanden angreifen.")
                 event.isCancelled = true
             }
         }

--- a/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/listener/PlayerActionListener.kt
@@ -39,6 +39,9 @@ class PlayerActionListener : Listener {
     @EventHandler
     fun onPlayerMove(event: PlayerMoveEvent) {
         val player = event.player
+        if(!event.hasChangedBlock()) {
+            return
+        }
         plugin.launch(plugin.entityDispatcher(player)) {
             if (FreezeManager.isPlayerFrozen(player)) {
                 sendFrozenMessage(player, "Du bist eingefroren und kannst dich nicht bewegen.")
@@ -49,11 +52,6 @@ class PlayerActionListener : Listener {
                     location.y++
                     player.teleport(location)
                 }
-
-                if(!event.hasChangedBlock()) {
-                    return@launch
-                }
-
                 event.isCancelled = true
             }
         }

--- a/src/main/kotlin/dev/slne/surfModerationTools/permissions/Permissions.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/permissions/Permissions.kt
@@ -8,5 +8,7 @@ object Permissions : PermissionRegistry() {
     private const val COMMAND_PREFIX = "$PREFIX.command"
 
     val COMMAND_ROTATE = create("$COMMAND_PREFIX.rotation")
+    val COMMAND_FREEZE = create("$COMMAND_PREFIX.freeze")
+    val COMMAND_UNFREEZE = create("$COMMAND_PREFIX.unfreeze")
 
 }

--- a/src/main/kotlin/dev/slne/surfModerationTools/utils/FreezeManager.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/utils/FreezeManager.kt
@@ -1,0 +1,28 @@
+package dev.slne.surfModerationTools.utils
+
+import org.bukkit.entity.Player
+import java.util.UUID
+
+object FreezeManager {
+    val frozenPlayers: MutableSet<UUID> = mutableSetOf()
+
+    fun freezePlayer(player: Player): Boolean {
+        if (!isPlayerFrozen(player)) {
+            frozenPlayers.add(player.uniqueId)
+            return true
+        }
+        return false
+    }
+
+    fun unfreezePlayer(player: Player): Boolean {
+        if (isPlayerFrozen(player)) {
+            frozenPlayers.remove(player.uniqueId)
+            return true
+        }
+        return false
+    }
+
+    fun isPlayerFrozen(player: Player): Boolean {
+        return player.uniqueId in frozenPlayers
+    }
+}

--- a/src/main/kotlin/dev/slne/surfModerationTools/utils/FreezeManager.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/utils/FreezeManager.kt
@@ -1,5 +1,6 @@
 package dev.slne.surfModerationTools.utils
 
+import dev.slne.surf.surfapi.core.api.util.mutableObjectSetOf
 import org.bukkit.entity.Player
 import java.util.UUID
 

--- a/src/main/kotlin/dev/slne/surfModerationTools/utils/FreezeManager.kt
+++ b/src/main/kotlin/dev/slne/surfModerationTools/utils/FreezeManager.kt
@@ -4,7 +4,7 @@ import org.bukkit.entity.Player
 import java.util.UUID
 
 object FreezeManager {
-    val frozenPlayers: MutableSet<UUID> = mutableSetOf()
+    val frozenPlayers = mutableObjectSetOf<UUID>()
 
     fun freezePlayer(player: Player): Boolean {
         if (!isPlayerFrozen(player)) {


### PR DESCRIPTION
This pull request introduces a new player freezing feature to the moderation tools plugin, allowing moderators to freeze and unfreeze players and restrict their in-game actions. It adds new commands, a listener to enforce freeze restrictions, and updates permissions and versioning.

### Player Freeze/Unfreeze Feature

* Added `freeze` and `unfreeze` commands, enabling moderators to freeze or unfreeze specific players via command, with appropriate permission checks and feedback messages.
* Implemented the `FreezeManager` utility to track frozen players and handle freeze/unfreeze operations.

### Enforcement of Freeze Restrictions

* Added `PlayerActionListener` to cancel player actions (movement, block breaking/placing, attacking, interacting, etc.) if the player is frozen, and unfreezes players on quit. Includes cooldown for repeated frozen messages.
* Registered the new listener in the plugin’s `onEnableAsync` lifecycle method.

### Permissions and Versioning

* Added new permissions for the freeze and unfreeze commands in `Permissions.kt`.
* Bumped plugin version from `1.0.0-beta` to `1.1.0-beta` in `gradle.properties`.

### Solved Issue
* https://github.com/SLNE-Development/surf-moderation-tools/issues/4
