### PR TITLE
feat: freeze timer

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.8-1.1.0-SNAPSHOT
+version=1.21.8-1.2.0-SNAPSHOT

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,6 +6,6 @@ buildscript {
         maven("https://repo.slne.dev/repository/maven-public/") { name = "maven-public" }
     }
     dependencies {
-        classpath("dev.slne.surf:surf-api-gradle-plugin:1.21.7+")
+        classpath("dev.slne.surf:surf-api-gradle-plugin:1.21.8+")
     }
 }

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/commands/FreezeCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/commands/FreezeCommand.kt
@@ -8,20 +8,24 @@ import dev.jorel.commandapi.kotlindsl.getValue
 import dev.jorel.commandapi.kotlindsl.playerArgument
 import dev.slne.surf.moderation.tools.plugin
 import dev.slne.surf.moderation.tools.service.freezeService
+import dev.slne.surf.moderation.tools.utils.DurationArgument
 import dev.slne.surf.moderation.tools.utils.PermissionRegistry
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
-import org.bukkit.Material
 import org.bukkit.entity.Player
 
+
 fun freezeCommand() = commandAPICommand("freeze") {
-    playerArgument("targetPlayer")
     withPermission(PermissionRegistry.COMMAND_FREEZE)
+    playerArgument("targetPlayer")
+    withArguments(DurationArgument.durationArgument("duration"))
 
     anyExecutor { sender, args ->
         val targetPlayer: Player by args
+        val duration: Long by args
 
-
-        if (freezeService.isFrozen(targetPlayer.uniqueId)) {
+        val targetUuid = targetPlayer.uniqueId
+        
+        if (freezeService.isFrozen(targetUuid)) {
             sender.sendText {
                 appendPrefix()
                 error("Der Spieler")
@@ -33,15 +37,19 @@ fun freezeCommand() = commandAPICommand("freeze") {
             return@anyExecutor
         }
 
-
-        freezeService.freeze(targetPlayer.uniqueId)
+        freezeService.freeze(targetUuid, duration)
 
         plugin.launch(plugin.entityDispatcher(targetPlayer)) {
-            if (targetPlayer.location.block.type == Material.AIR) {
-                val location = targetPlayer.location.clone()
-                location.y = targetPlayer.world.getHighestBlockYAt(location).toDouble()
-                location.y++
-                targetPlayer.teleportAsync(location)
+            val location = targetPlayer.location.clone()
+            val world = location.world
+
+            for (y in location.blockY downTo 0) {
+                val block = world.getBlockAt(location.blockX, y, location.blockZ)
+                if (block.type.isSolid) {
+                    location.y = y + 1.0
+                    targetPlayer.teleportAsync(location)
+                    break
+                }
             }
         }
 

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/commands/FreezeCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/commands/FreezeCommand.kt
@@ -8,8 +8,8 @@ import dev.jorel.commandapi.kotlindsl.getValue
 import dev.jorel.commandapi.kotlindsl.playerArgument
 import dev.slne.surf.moderation.tools.plugin
 import dev.slne.surf.moderation.tools.service.freezeService
-import dev.slne.surf.moderation.tools.utils.DurationArgument
 import dev.slne.surf.moderation.tools.utils.PermissionRegistry
+import dev.slne.surf.moderation.tools.utils.durationArgument
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import org.bukkit.entity.Player
 
@@ -17,7 +17,7 @@ import org.bukkit.entity.Player
 fun freezeCommand() = commandAPICommand("freeze") {
     withPermission(PermissionRegistry.COMMAND_FREEZE)
     playerArgument("targetPlayer")
-    withArguments(DurationArgument.durationArgument("duration"))
+    durationArgument("duration")
 
     anyExecutor { sender, args ->
         val targetPlayer: Player by args

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/commands/FreezeCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/commands/FreezeCommand.kt
@@ -43,13 +43,20 @@ fun freezeCommand() = commandAPICommand("freeze") {
             val location = targetPlayer.location.clone()
             val world = location.world
 
+            var teleported = false
             for (y in location.blockY downTo 0) {
                 val block = world.getBlockAt(location.blockX, y, location.blockZ)
                 if (block.type.isSolid) {
                     location.y = y + 1.0
                     targetPlayer.teleportAsync(location)
+                    teleported = true
                     break
                 }
+            }
+            if (!teleported) {
+                // Fallback: teleport to world spawn location
+                val spawnLocation = world.spawnLocation
+                targetPlayer.teleportAsync(spawnLocation)
             }
         }
 

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/commands/FreezeCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/commands/FreezeCommand.kt
@@ -24,7 +24,7 @@ fun freezeCommand() = commandAPICommand("freeze") {
         val duration: Long by args
 
         val targetUuid = targetPlayer.uniqueId
-        
+
         if (freezeService.isFrozen(targetUuid)) {
             sender.sendText {
                 appendPrefix()
@@ -54,9 +54,8 @@ fun freezeCommand() = commandAPICommand("freeze") {
                 }
             }
             if (!teleported) {
-                // Fallback: teleport to world spawn location
-                val spawnLocation = world.spawnLocation
-                targetPlayer.teleportAsync(spawnLocation)
+                val fallbackLocation = world.spawnLocation
+                targetPlayer.teleportAsync(fallbackLocation)
             }
         }
 

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/listener/PlayerActionListener.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/listener/PlayerActionListener.kt
@@ -13,7 +13,6 @@ import org.bukkit.event.entity.EntityDamageByEntityEvent
 import org.bukkit.event.player.PlayerInteractEntityEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.player.PlayerMoveEvent
-import org.bukkit.event.player.PlayerQuitEvent
 import java.util.*
 import java.util.concurrent.TimeUnit
 
@@ -90,12 +89,6 @@ class PlayerActionListener : Listener {
             event.cancel()
         }
     }
-
-    @EventHandler
-    fun onQuit(event: PlayerQuitEvent) {
-        freezeService.unfreeze(event.player.uniqueId)
-    }
-
 
     private fun sendResultMessage(player: Player, message: String) {
         if ((messageCooldown.getIfPresent(player.uniqueId) ?: 0) < System.currentTimeMillis()) {

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/listener/PlayerActionListener.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/listener/PlayerActionListener.kt
@@ -90,6 +90,18 @@ class PlayerActionListener : Listener {
         }
     }
 
+    @EventHandler
+    fun onDamage(event: EntityDamageByEntityEvent) {
+        val entity = event.entity
+        if (entity !is Player) {
+            return
+        }
+
+        if (freezeService.isFrozen(entity.uniqueId)) {
+            event.cancel()
+        }
+    }
+
     private fun sendResultMessage(player: Player, message: String) {
         if ((messageCooldown.getIfPresent(player.uniqueId) ?: 0) < System.currentTimeMillis()) {
             player.sendText {

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/listener/PlayerActionListener.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/listener/PlayerActionListener.kt
@@ -10,6 +10,7 @@ import org.bukkit.event.Listener
 import org.bukkit.event.block.BlockBreakEvent
 import org.bukkit.event.block.BlockPlaceEvent
 import org.bukkit.event.entity.EntityDamageByEntityEvent
+import org.bukkit.event.entity.EntityDamageEvent
 import org.bukkit.event.player.PlayerInteractEntityEvent
 import org.bukkit.event.player.PlayerInteractEvent
 import org.bukkit.event.player.PlayerMoveEvent
@@ -91,12 +92,11 @@ class PlayerActionListener : Listener {
     }
 
     @EventHandler
-    fun onDamage(event: EntityDamageByEntityEvent) {
+    fun onDamage(event: EntityDamageEvent) {
         val entity = event.entity
         if (entity !is Player) {
             return
         }
-
         if (freezeService.isFrozen(entity.uniqueId)) {
             event.cancel()
         }

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/service/FreezeService.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/service/FreezeService.kt
@@ -16,7 +16,7 @@ class FreezeService {
 
     fun unfreeze(uuid: UUID) {
         frozenPlayers.remove(uuid)
-        freezeTimer.getIfPresent(uuid)?.let { freezeTimer.invalidate(uuid) }
+        freezeTimer.invalidate(uuid)
     }
 
     fun isFrozen(uuid: UUID): Boolean {

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/service/FreezeService.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/service/FreezeService.kt
@@ -20,13 +20,14 @@ class FreezeService {
     }
 
     fun isFrozen(uuid: UUID): Boolean {
-        if (frozenPlayers.contains(uuid)) {
+        val isFrozen = frozenPlayers.contains(uuid)
+        if (isFrozen) {
             if ((freezeTimer.getIfPresent(uuid) ?: 0) < System.currentTimeMillis()) {
                 unfreeze(uuid)
                 return false
             }
         }
-        return frozenPlayers.contains(uuid)
+        return isFrozen
     }
 
     companion object {

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/service/FreezeService.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/service/FreezeService.kt
@@ -22,7 +22,8 @@ class FreezeService {
     fun isFrozen(uuid: UUID): Boolean {
         val isFrozen = frozenPlayers.contains(uuid)
         if (isFrozen) {
-            if ((freezeTimer.getIfPresent(uuid) ?: 0) < System.currentTimeMillis()) {
+            val expireTime = freezeTimer.getIfPresent(uuid)
+            if (expireTime == null || expireTime < System.currentTimeMillis()) {
                 unfreeze(uuid)
                 return false
             }

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/utils/DurationArgument.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/utils/DurationArgument.kt
@@ -1,38 +1,53 @@
 package dev.slne.surf.moderation.tools.utils
 
+import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.arguments.Argument
 import dev.jorel.commandapi.arguments.ArgumentSuggestions
 import dev.jorel.commandapi.arguments.CustomArgument
 import dev.jorel.commandapi.arguments.StringArgument
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 
-object DurationArgument {
 
-    fun durationArgument(arg: String): Argument<Long> {
-        return CustomArgument(StringArgument(arg)) { argument ->
-            parseRangeToMillis(argument.input)
-                ?: throw CustomArgument.CustomArgumentException.fromMessageBuilder(
-                    CustomArgument.MessageBuilder("Invalid duration format. Use s, m, h, d, w.")
-                )
-        }.replaceSuggestions(ArgumentSuggestions.strings { _ ->
+class DurationArgument(arg: String) : CustomArgument<Long, String>(
+    StringArgument(arg),
+    { argument ->
+        parseRangeToMillis(argument.input)
+            ?: throw CustomArgumentException.fromAdventureComponent {
+                buildText {
+                    appendPrefix()
+                    error("Nutze das Format <Zahl><Einheit> (s, m, h, d, w) für die Dauer.")
+                }
+            }
+    }
+) {
+    init {
+        replaceSuggestions(ArgumentSuggestions.strings { _ ->
             arrayOf("s", "m", "h", "d", "w")
         })
     }
+}
 
-    private val regex = Regex("^(\\d+)([smhdw])\$")
+inline fun CommandAPICommand.durationArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): CommandAPICommand =
+    withArguments(DurationArgument(nodeName).setOptional(optional).apply(block))
 
-    private fun parseRangeToMillis(input: String): Long? {
-        val match = regex.matchEntire(input.trim()) ?: return null
+private val regex = Regex("^(\\d+)([smhdw])\$")
 
-        val (valueStr, unit) = match.destructured
-        val value = valueStr.toLongOrNull() ?: return null
+private fun parseRangeToMillis(input: String): Long? {
+    val match = regex.matchEntire(input.trim()) ?: return null
 
-        return when (unit.lowercase()) {
-            "s" -> value * 1000
-            "m" -> value * 60 * 1000
-            "h" -> value * 60 * 60 * 1000
-            "d" -> value * 24 * 60 * 60 * 1000
-            "w" -> value * 7 * 24 * 60 * 60 * 1000
-            else -> null
-        }
+    val (valueStr, unit) = match.destructured
+    val value = valueStr.toLongOrNull() ?: return null
+
+    return when (unit.lowercase()) {
+        "s" -> value * 1000
+        "m" -> value * 60 * 1000
+        "h" -> value * 60 * 60 * 1000
+        "d" -> value * 24 * 60 * 60 * 1000
+        "w" -> value * 7 * 24 * 60 * 60 * 1000
+        else -> null
     }
 }

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/utils/DurationArgument.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/utils/DurationArgument.kt
@@ -18,7 +18,7 @@ object DurationArgument {
         })
     }
 
-    private val regex = Regex("^(\\d+)([smhdwp])\$")
+    private val regex = Regex("^(\\d+)([smhdw])\$")
 
     private fun parseRangeToMillis(input: String): Long? {
         val match = regex.matchEntire(input.trim()) ?: return null

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/utils/DurationArgument.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/utils/DurationArgument.kt
@@ -1,0 +1,38 @@
+package dev.slne.surf.moderation.tools.utils
+
+import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
+import dev.jorel.commandapi.arguments.CustomArgument
+import dev.jorel.commandapi.arguments.StringArgument
+
+object DurationArgument {
+
+    fun durationArgument(arg: String): Argument<Long> {
+        return CustomArgument(StringArgument(arg)) { argument ->
+            parseRangeToMillis(argument.input)
+                ?: throw CustomArgument.CustomArgumentException.fromMessageBuilder(
+                    CustomArgument.MessageBuilder("Invalid duration format. Use s, m, h, d, w.")
+                )
+        }.replaceSuggestions(ArgumentSuggestions.strings { _ ->
+            arrayOf("s", "m", "h", "d", "w")
+        })
+    }
+
+    private val regex = Regex("^(\\d+)([smhdwp])\$")
+
+    private fun parseRangeToMillis(input: String): Long? {
+        val match = regex.matchEntire(input.trim()) ?: return null
+
+        val (valueStr, unit) = match.destructured
+        val value = valueStr.toLongOrNull() ?: return null
+
+        return when (unit.lowercase()) {
+            "s" -> value * 1000
+            "m" -> value * 60 * 1000
+            "h" -> value * 60 * 60 * 1000
+            "d" -> value * 24 * 60 * 60 * 1000
+            "w" -> value * 7 * 24 * 60 * 60 * 1000
+            else -> null
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a duration-based freeze feature to the moderation tools, allowing admins to freeze players for a specified time period. It also refactors the freeze service to support timed unfreezing and improves the freeze command's usability. Additionally, it updates dependencies and versioning.

### Feature: Duration-based Freeze Functionality
* Added a new `DurationArgument` utility to parse and validate duration inputs (e.g., "10m", "2h") for freeze commands (`DurationArgument.kt`).
* Updated `FreezeService` to support timed freezing, automatically unfreezing players when their freeze duration expires (`FreezeService.kt`).
* Refactored `freezeCommand` to accept a duration argument, pass it to the freeze service, and improve teleport logic for frozen players (`FreezeCommand.kt`). [[1]](diffhunk://#diff-8c859715cd4fa20c59fb3fd16e7c35493923a673b3622fe20c5ccdba89d8357cR11-R28) [[2]](diffhunk://#diff-8c859715cd4fa20c59fb3fd16e7c35493923a673b3622fe20c5ccdba89d8357cL36-R52)

### Codebase Maintenance
* Removed the event handler that automatically unfroze players on quit, as timed unfreezing now handles this (`PlayerActionListener.kt`). [[1]](diffhunk://#diff-f7fae353065a5e7c43d61d5073cee677f2633936d3900337e68fc13fcf93da0dL94-L99) [[2]](diffhunk://#diff-f7fae353065a5e7c43d61d5073cee677f2633936d3900337e68fc13fcf93da0dL16)

### Dependency and Version Updates
* Bumped project version to `1.21.8-1.2.0-SNAPSHOT` in `gradle.properties`.
* Updated `surf-api-gradle-plugin` dependency to version `1.21.8+` in `settings.gradle.kts`.

### Solved Issues
* https://github.com/SLNE-Development/surf-moderation-tools/issues/10#issue-3431627794