### PR TITLE
refactor: rename BukkitMain to PaperMain and update related references

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ dependencies {
 }
 
 surfPaperPluginApi {
-    mainClass("dev.slne.surf.moderation.tools.BukkitMain")
+    mainClass("dev.slne.surf.moderation.tools.PaperMain")
     foliaSupported(true)
     generateLibraryLoader(false)
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.11-1.3.3-SNAPSHOT
+version=1.21.11-1.3.4-SNAPSHOT

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -5,7 +5,4 @@ pluginManagement {
         gradlePluginPortal()
         maven("https://repo.slne.dev/repository/maven-public/") { name = "maven-public" }
     }
-    dependencies {
-        classpath("dev.slne.surf:surf-api-gradle-plugin:1.21.11+")
-    }
 }

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/PaperMain.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/PaperMain.kt
@@ -7,9 +7,9 @@ import dev.slne.surf.moderation.tools.listener.PlayerActionListener
 import dev.slne.surf.surfapi.bukkit.api.event.register
 import org.bukkit.plugin.java.JavaPlugin
 
-val plugin get() = JavaPlugin.getPlugin(BukkitMain::class.java)
+val plugin get() = JavaPlugin.getPlugin(PaperMain::class.java)
 
-class BukkitMain : SuspendingJavaPlugin() {
+class PaperMain : SuspendingJavaPlugin() {
     override suspend fun onLoadAsync() {
         SurfModerationToolConfig.init()
     }

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/service/FaqService.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/service/FaqService.kt
@@ -8,13 +8,11 @@ import dev.slne.surf.moderation.tools.faq.Faq
 import dev.slne.surf.moderation.tools.plugin
 import dev.slne.surf.moderation.tools.utils.appendArtyPrefix
 import dev.slne.surf.surfapi.bukkit.api.extensions.server
-import dev.slne.surf.surfapi.core.api.messages.Colors
 import dev.slne.surf.surfapi.core.api.messages.adventure.playSound
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import net.kyori.adventure.sound.Sound.Source
-import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Sound
 import org.bukkit.entity.Player
@@ -59,9 +57,7 @@ object FaqService {
                         target.sendText {
                             appendArtyPrefix()
                             append {
-                                text("@${target.name}")
-                                decorate(TextDecoration.BOLD)
-                                color(TextColor.color(Colors.VARIABLE_VALUE))
+                                variableValue("@${target.name}", TextDecoration.BOLD)
                             }
                             appendSpace()
                             append(faq.message)

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/service/FaqService.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/service/FaqService.kt
@@ -56,9 +56,7 @@ object FaqService {
                     launch(plugin.entityDispatcher(target)) {
                         target.sendText {
                             appendArtyPrefix()
-                            append {
-                                variableValue("@${target.name}", TextDecoration.BOLD)
-                            }
+                            variableValue("@${target.name}", TextDecoration.BOLD)
                             appendSpace()
                             append(faq.message)
                         }

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/service/FaqService.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/service/FaqService.kt
@@ -8,11 +8,13 @@ import dev.slne.surf.moderation.tools.faq.Faq
 import dev.slne.surf.moderation.tools.plugin
 import dev.slne.surf.moderation.tools.utils.appendArtyPrefix
 import dev.slne.surf.surfapi.bukkit.api.extensions.server
+import dev.slne.surf.surfapi.core.api.messages.Colors
 import dev.slne.surf.surfapi.core.api.messages.adventure.playSound
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import net.kyori.adventure.sound.Sound.Source
+import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Sound
 import org.bukkit.entity.Player
@@ -57,16 +59,17 @@ object FaqService {
                         target.sendText {
                             appendArtyPrefix()
                             append {
-                                text(target.name)
+                                text("@${target.name}")
                                 decorate(TextDecoration.BOLD)
+                                color(TextColor.color(Colors.VARIABLE_VALUE))
                             }
                             appendSpace()
                             append(faq.message)
                         }
 
                         target.playSound(useSelfEmitter = true) {
-                            type(Sound.BLOCK_NOTE_BLOCK_BELL)
-                            source(Source.PLAYER)
+                            type(Sound.ENTITY_CHICKEN_EGG)
+                            source(Source.MASTER)
                             volume(1f)
                             pitch(1f)
                         }


### PR DESCRIPTION
This pull request includes several updates to the moderation tools plugin, focusing on refactoring class names for clarity, updating the plugin version, and improving the FAQ service's user feedback. The most important changes are grouped below:

### Refactoring and Versioning

* Renamed the main plugin class from `BukkitMain` to `PaperMain` and updated the global `plugin` getter to reference the new class for better clarity and consistency. (`src/main/kotlin/dev/slne/surf/moderation/tools/PaperMain.kt`)
* Updated the project version to `1.21.11-1.3.4-SNAPSHOT` in `gradle.properties`.
* Removed a direct dependency on the `surf-api-gradle-plugin` from `settings.gradle.kts` to clean up plugin management.

### FAQ Service Improvements

* Enhanced the FAQ service's message formatting by prefixing player names with `@`, applying bold decoration, and setting the color to `Colors.VARIABLE_VALUE`. (`src/main/kotlin/dev/slne/surf/moderation/tools/service/FaqService.kt`)
* Changed the feedback sound for FAQ responses from `BLOCK_NOTE_BLOCK_BELL` (player source) to `ENTITY_CHICKEN_EGG` (master source) for a more distinctive effect. (`src/main/kotlin/dev/slne/surf/moderation/tools/service/FaqService.kt`)
* Added necessary imports for `Colors` and `TextColor` to support the new message formatting. (`src/main/kotlin/dev/slne/surf/moderation/tools/service/FaqService.kt`)