### PR TITLE
feat: add pingPlayer command to notify players with an optional message

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ provides quick administrative and support functions directly in-game.
   ☀️ Unfreeze a player.
     - Permission: ``surf.moderation.tools.command.unfreeze``
 
+- **`/pingPlayer <Player> <WithMessage>`**   
+  - 📍 Ping a player with a auditory indicator and an optional message.
+  - Permission: ``surf.moderation.tools.command.pingPlayer``
+
 - **`/faq <FAQ> [Player]`**
   📄 Send pre-defined answers to frequently asked questions.
   - Permission: ``surf.moderation.tools.command.faq``

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=1.21.11-1.3.6-SNAPSHOT
+version=1.21.11-1.3.7-SNAPSHOT

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/PaperMain.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/PaperMain.kt
@@ -22,6 +22,7 @@ class PaperMain : SuspendingJavaPlugin() {
         freezeCommand()
         unfreezeCommand()
         stopInteraction()
+        pingPlayerCommand()
 
         PlayerActionListener.register()
     }

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/commands/PlayerPingCommand.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/commands/PlayerPingCommand.kt
@@ -1,0 +1,55 @@
+package dev.slne.surf.moderation.tools.commands
+
+import com.github.shynixn.mccoroutine.folia.entityDispatcher
+import dev.jorel.commandapi.kotlindsl.booleanArgument
+import dev.jorel.commandapi.kotlindsl.commandAPICommand
+import dev.jorel.commandapi.kotlindsl.getValue
+import dev.jorel.commandapi.kotlindsl.entitySelectorArgumentOnePlayer
+import dev.slne.surf.moderation.tools.plugin
+import dev.slne.surf.moderation.tools.utils.PermissionRegistry
+import dev.slne.surf.moderation.tools.utils.appendArtyPrefix
+import dev.slne.surf.surfapi.bukkit.api.command.executors.anyExecutorSuspend
+import dev.slne.surf.surfapi.core.api.messages.adventure.playSound
+import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
+import kotlinx.coroutines.withContext
+import net.kyori.adventure.sound.Sound.Source
+import net.kyori.adventure.text.format.TextDecoration
+import org.bukkit.Sound
+import org.bukkit.entity.Player
+
+fun pingPlayerCommand() = commandAPICommand("pingPlayer") {
+    entitySelectorArgumentOnePlayer("target")
+    booleanArgument("message")
+    withPermission(PermissionRegistry.COMMAND_PING_PLAYER)
+
+    anyExecutorSuspend { sender, args ->
+
+        val target: Player by args
+        val message: Boolean by args
+
+        withContext(plugin.entityDispatcher(target)) {
+            if (message) {
+                target.sendText {
+                    appendArtyPrefix()
+                    variableValue("@${target.name}", TextDecoration.BOLD)
+                    appendSpace()
+                    text("Bist du da?")
+                }
+            }
+
+            target.playSound(useSelfEmitter = true) {
+                type(Sound.BLOCK_BELL_USE)
+                source(Source.MASTER)
+                volume(1f)
+                pitch(1f)
+            }
+
+            sender.sendText {
+                appendSuccessPrefix()
+                variableValue(target.name)
+                success(" wurde erfolgreich gepingt.")
+            }
+        }
+    }
+}
+

--- a/src/main/kotlin/dev/slne/surf/moderation/tools/utils/PermissionRegistry.kt
+++ b/src/main/kotlin/dev/slne/surf/moderation/tools/utils/PermissionRegistry.kt
@@ -11,5 +11,6 @@ object PermissionRegistry : PermissionRegistry() {
     val COMMAND_FREEZE = create("$COMMAND_PREFIX.freeze")
     val COMMAND_UNFREEZE = create("$COMMAND_PREFIX.unfreeze")
     val COMMAND_FAQ = create("$COMMAND_PREFIX.faq")
+    val COMMAND_PING_PLAYER = create("$COMMAND_PREFIX.pingplayer")
     val COMMAND_SURF_MOD_TOOLS = create("$COMMAND_PREFIX.surfmodtools")
 }


### PR DESCRIPTION
This pull request introduces a new administrative command for moderators to ping players in-game, along with the necessary documentation, permissions, and version update. The most important changes are grouped below:

### New Feature: Player Ping Command

* Added the `/pingPlayer <Player> <WithMessage>` command, allowing moderators to ping a player with an auditory indicator and an optional message. This includes the implementation in `PlayerPingCommand.kt`, registration in the plugin's main class, and documentation in the `README.md`. [[1]](diffhunk://#diff-3b30af78ab085b0aece1471c84ec24f592e0b6bc25d6c17ee6565ea44ff6fe8aR1-R55) [[2]](diffhunk://#diff-5fe3576b6bf6769cd32cadbf9485882aab52c34538b54f95bbf014b1a5cf35a8R25) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22-R25)

### Permissions

* Registered a new permission node `surf.moderation.tools.command.pingplayer` in the `PermissionRegistry` for controlling access to the ping player command.

### Documentation and Versioning

* Updated the `README.md` to document the new `/pingPlayer` command and its usage.
* Bumped the plugin version to `1.21.11-1.3.7-SNAPSHOT` in `gradle.properties` to reflect the new feature.