### PR TITLE
Update version to 2.1.5 in gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=2.1.4
+version=2.1.5


### PR DESCRIPTION
This pull request updates the project version in `gradle.properties` from `2.1.4` to `2.1.5`. This is a routine version bump, likely to reflect new changes or fixes since the last release.